### PR TITLE
feat: add environment variable support for Prometheus configuration

### DIFF
--- a/infrastructure/config/app_config.go
+++ b/infrastructure/config/app_config.go
@@ -209,7 +209,7 @@ func DefaultConfig() *AppConfig {
 		Version:    1, // Current configuration version
 		ClaudePath: "",
 		Prometheus: &PrometheusConfig{
-			RemoteWriteURL:      "http://localhost:9090/api/v1/write", // デフォルトのPrometheus URL
+			RemoteWriteURL:      "", // Empty by default, must be set via environment variable or config.json
 			RemoteWriteUsername: "",
 			RemoteWritePassword: "",
 			URL:                 "",

--- a/infrastructure/repository/noop_metrics_repository.go
+++ b/infrastructure/repository/noop_metrics_repository.go
@@ -1,0 +1,32 @@
+package repository
+
+import (
+	"github.com/ca-srg/tosage/domain/repository"
+)
+
+// NoOpMetricsRepository is a no-op implementation of MetricsRepository
+// Used when Prometheus is not configured
+type NoOpMetricsRepository struct{}
+
+// NewNoOpMetricsRepository creates a new no-op metrics repository
+func NewNoOpMetricsRepository() repository.MetricsRepository {
+	return &NoOpMetricsRepository{}
+}
+
+// SendTokenMetric does nothing
+func (r *NoOpMetricsRepository) SendTokenMetric(totalTokens int, hostLabel string, metricName string) error {
+	// No-op: do nothing
+	return nil
+}
+
+// SendTokenMetricWithTimezone does nothing
+func (r *NoOpMetricsRepository) SendTokenMetricWithTimezone(totalTokens int, hostLabel string, metricName string, timezoneInfo repository.TimezoneInfo) error {
+	// No-op: do nothing
+	return nil
+}
+
+// Close does nothing
+func (r *NoOpMetricsRepository) Close() error {
+	// No-op: do nothing
+	return nil
+}


### PR DESCRIPTION
## Overview
This PR adds environment variable support for Prometheus configuration, making it easier to deploy tosage in containerized environments without requiring a config.json file.

## Changes
- Changed default RemoteWriteURL to empty string instead of localhost URL
- Added NoOpMetricsRepository for when Prometheus is not configured
- Implemented environment variable loading for all Prometheus settings using Netflix/go-env
- Added debug logging to show when environment variables override configuration

## Testing
- [ ] Local build succeeds
- [ ] All tests pass
- [ ] New features/fixes work as expected

## Related Issues
- N/A

## Additional Notes
This change allows users to configure Prometheus entirely via environment variables:
- `TOSAGE_PROMETHEUS_REMOTE_WRITE_URL`
- `TOSAGE_PROMETHEUS_REMOTE_WRITE_USERNAME`
- `TOSAGE_PROMETHEUS_REMOTE_WRITE_PASSWORD`
- etc.

When RemoteWriteURL is not set (empty string), the application will use a no-op metrics repository instead of failing, making it more flexible for users who may not have Prometheus set up yet.